### PR TITLE
gracefully handle db failures on startup

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -13,12 +13,15 @@ import (
 
 func main() {
 	// Bootstrapping schema at startup to keep local/dev deployments self-contained.
-	database.Connect()
+	if err := database.Connect(); err != nil {
+		log.Fatalf("Startup failed: %v", err)
+	}
 	database.InitSchema()
 
 	// Periodic cleanup prevents the revoked-token table from growing forever.
 	go func() {
 		ticker := time.NewTicker(1 * time.Hour)
+		defer ticker.Stop()
 		for range ticker.C {
 			if err := database.CleanupTokens(); err != nil {
 				log.Printf("Error cleaning up expired tokens: %v", err)

--- a/backend/internal/database/db.go
+++ b/backend/internal/database/db.go
@@ -5,12 +5,23 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
+	"sync/atomic"
 	"time"
 
 	_ "github.com/lib/pq"
 )
 
-var DB *sql.DB
+var (
+	DB        *sql.DB
+	dbHealthy atomic.Bool
+)
+
+const (
+	dbMaxStartupAttempts  = 5
+	dbStartupBaseDelay    = 2 * time.Second
+	dbStartupMaxDelay     = 30 * time.Second
+	dbHealthCheckInterval = 10 * time.Second
+)
 
 func Connect() {
 	connStr := fmt.Sprintf("host=%s user=%s password=%s dbname=%s port=%d sslmode=disable",
@@ -26,15 +37,61 @@ func Connect() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	if err = DB.Ping(); err != nil {
-		log.Fatal("Could not connect to database:", err)
-	}
 
 	// Conservative pool settings avoid exhausting DB connections in small deployments.
 	DB.SetMaxOpenConns(25)
 	DB.SetMaxIdleConns(5)
 	// Recycling connections helps recover from stale network state over long uptimes.
 	DB.SetConnMaxLifetime(5 * time.Minute)
+
+	if err = pingWithRetry(); err != nil {
+		log.Printf("Database unavailable after %d attempts, starting degraded: %v", dbMaxStartupAttempts, err)
+		dbHealthy.Store(false)
+	} else {
+		log.Println("Database connection established")
+		dbHealthy.Store(true)
+	}
+
+	go monitorDatabase()
+}
+
+func pingWithRetry() error {
+	delay := dbStartupBaseDelay
+	for attempt := 1; attempt <= dbMaxStartupAttempts; attempt++ {
+		if err := DB.Ping(); err == nil {
+			return nil
+		} else {
+			log.Printf("Database ping failed (attempt %d/%d): %v", attempt, dbMaxStartupAttempts, err)
+		}
+		if attempt < dbMaxStartupAttempts {
+			log.Printf("Retrying in %s...", delay)
+			time.Sleep(delay)
+			delay *= 2
+			if delay > dbStartupMaxDelay {
+				delay = dbStartupMaxDelay
+			}
+		}
+	}
+	return fmt.Errorf("database unreachable after %d attempts", dbMaxStartupAttempts)
+}
+func monitorDatabase() {
+	ticker := time.NewTicker(dbHealthCheckInterval)
+	defer ticker.Stop()
+	for range ticker.C {
+		if err := DB.Ping(); err != nil {
+			if dbHealthy.CompareAndSwap(true, false) {
+				log.Printf("Database connection lost: %v", err)
+			}
+			continue
+		}
+		if dbHealthy.CompareAndSwap(false, true) {
+			log.Println("Database connection restored")
+		}
+	}
+}
+
+func IsDBHealthy() bool {
+	return dbHealthy.Load()
 }
 
 func InitSchema() {

--- a/backend/internal/database/db.go
+++ b/backend/internal/database/db.go
@@ -5,25 +5,20 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
-	"sync/atomic"
 	"time"
 
 	_ "github.com/lib/pq"
 )
 
-var (
-	DB        *sql.DB
-	dbHealthy atomic.Bool
-)
+var DB *sql.DB
 
 const (
-	dbMaxStartupAttempts  = 5
-	dbStartupBaseDelay    = 2 * time.Second
-	dbStartupMaxDelay     = 30 * time.Second
-	dbHealthCheckInterval = 10 * time.Second
+	dbMaxStartupAttempts = 5
+	dbStartupBaseDelay   = 2 * time.Second
+	dbStartupMaxDelay    = 30 * time.Second
 )
 
-func Connect() {
+func Connect() error {
 	connStr := fmt.Sprintf("host=%s user=%s password=%s dbname=%s port=%d sslmode=disable",
 		config.Config.POSTGRES_HOST,
 		config.Config.POSTGRES_USER,
@@ -35,7 +30,7 @@ func Connect() {
 	var err error
 	DB, err = sql.Open("postgres", connStr)
 	if err != nil {
-		log.Fatal(err)
+		return fmt.Errorf("failed to open database: %w", err)
 	}
 
 	// Conservative pool settings avoid exhausting DB connections in small deployments.
@@ -45,14 +40,12 @@ func Connect() {
 	DB.SetConnMaxLifetime(5 * time.Minute)
 
 	if err = pingWithRetry(); err != nil {
-		log.Printf("Database unavailable after %d attempts, starting degraded: %v", dbMaxStartupAttempts, err)
-		dbHealthy.Store(false)
-	} else {
-		log.Println("Database connection established")
-		dbHealthy.Store(true)
+		DB.Close()
+		return fmt.Errorf("database unavailable after %d attempts: %w", dbMaxStartupAttempts, err)
 	}
 
-	go monitorDatabase()
+	log.Println("Database connection established")
+	return nil
 }
 
 func pingWithRetry() error {
@@ -75,29 +68,7 @@ func pingWithRetry() error {
 	return fmt.Errorf("database unreachable after %d attempts", dbMaxStartupAttempts)
 }
 
-func monitorDatabase() {
-	ticker := time.NewTicker(dbHealthCheckInterval)
-	defer ticker.Stop()
-	for range ticker.C {
-		if err := DB.Ping(); err != nil {
-			if dbHealthy.CompareAndSwap(true, false) {
-				log.Printf("Database connection lost: %v", err)
-			}
-			continue
-		}
-		if dbHealthy.CompareAndSwap(false, true) {
-			log.Println("Database connection restored")
-		}
-	}
-}
-
-func IsDBHealthy() bool {
-	return dbHealthy.Load()
-}
-
 func InitSchema() {
-	// Schema is assumed to be pre-initialized (e.g., via CI/CD pipelines).
-	//TODO: remove after actual implementation
 	log.Println("Database connection initialized. Assuming schema is already present.")
 }
 

--- a/backend/internal/database/db.go
+++ b/backend/internal/database/db.go
@@ -74,6 +74,7 @@ func pingWithRetry() error {
 	}
 	return fmt.Errorf("database unreachable after %d attempts", dbMaxStartupAttempts)
 }
+
 func monitorDatabase() {
 	ticker := time.NewTicker(dbHealthCheckInterval)
 	defer ticker.Stop()

--- a/backend/internal/middleware/auth.go
+++ b/backend/internal/middleware/auth.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"capuchin/internal/config"
 	"capuchin/internal/database"
+	"database/sql"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -21,10 +22,19 @@ func AuthRequired() gin.HandlerFunc {
 		// Accept standard Authorization header format without forcing clients to preprocess it.
 		tokenStr = strings.TrimPrefix(tokenStr, "Bearer ")
 
+		if !database.IsDBHealthy() {
+			c.AbortWithStatusJSON(503, gin.H{"error": "authentication service unavailable"})
+			return
+		}
+
 		var exists bool
 		// Check revocation before claim extraction so logout takes effect immediately.
 		err := database.DB.QueryRow("SELECT EXISTS(SELECT 1 FROM blacklisted_tokens WHERE token=$1)", tokenStr).Scan(&exists)
-		if err == nil && exists {
+		if err != nil && err != sql.ErrNoRows {
+			c.AbortWithStatusJSON(503, gin.H{"error": "authentication service unavailable"})
+			return
+		}
+		if exists {
 			c.AbortWithStatusJSON(401, gin.H{"error": "Token has been revoked"})
 			return
 		}

--- a/backend/internal/middleware/auth.go
+++ b/backend/internal/middleware/auth.go
@@ -22,11 +22,6 @@ func AuthRequired() gin.HandlerFunc {
 		// Accept standard Authorization header format without forcing clients to preprocess it.
 		tokenStr = strings.TrimPrefix(tokenStr, "Bearer ")
 
-		if !database.IsDBHealthy() {
-			c.AbortWithStatusJSON(503, gin.H{"error": "authentication service unavailable"})
-			return
-		}
-
 		var exists bool
 		// Check revocation before claim extraction so logout takes effect immediately.
 		err := database.DB.QueryRow("SELECT EXISTS(SELECT 1 FROM blacklisted_tokens WHERE token=$1)", tokenStr).Scan(&exists)

--- a/backend/internal/routes/routes.go
+++ b/backend/internal/routes/routes.go
@@ -1,7 +1,6 @@
 package routes
 
 import (
-	"capuchin/internal/database"
 	"capuchin/internal/handlers"
 	"capuchin/internal/middleware"
 
@@ -13,12 +12,9 @@ func SetupRoutes(router *gin.Engine, authHandler *handlers.AuthHandler, todoHand
 	router.Use(middleware.ErrorHandler())
 
 	router.GET("/health", func(c *gin.Context) {
-		if !database.IsDBHealthy() {
-			c.JSON(503, gin.H{"status": "degraded", "db": "down"})
-			return
-		}
-		c.JSON(200, gin.H{"status": "ok", "db": "up"})
+		c.JSON(200, gin.H{"status": "ok"})
 	})
+
 	router.POST("/signup", authHandler.Signup)
 	router.POST("/login", authHandler.Login)
 

--- a/backend/internal/routes/routes.go
+++ b/backend/internal/routes/routes.go
@@ -1,6 +1,7 @@
 package routes
 
 import (
+	"capuchin/internal/database"
 	"capuchin/internal/handlers"
 	"capuchin/internal/middleware"
 
@@ -12,7 +13,11 @@ func SetupRoutes(router *gin.Engine, authHandler *handlers.AuthHandler, todoHand
 	router.Use(middleware.ErrorHandler())
 
 	router.GET("/health", func(c *gin.Context) {
-		c.JSON(200, gin.H{"status": "ok"})
+		if !database.IsDBHealthy() {
+			c.JSON(503, gin.H{"status": "degraded", "db": "down"})
+			return
+		}
+		c.JSON(200, gin.H{"status": "ok", "db": "up"})
 	})
 	router.POST("/signup", authHandler.Signup)
 	router.POST("/login", authHandler.Login)


### PR DESCRIPTION
Fixes #55 

## Problem
Server was crashing immediately on startup if the database failed to connect, due to log.Fatal() being called on the first failed ping.


## Changes

Database Layer (db.go)
- Background Health Monitoring: Added goroutine that pings DB every 10 seconds and updates atomic health flag.
- Connect() now attempt 5 retries with exponential backoff instead of direct log.fatal() on ping failure. Updated fixed backoff to exponential backoff.
- Health check api endpoint: this is to check isDBHealthy() function for runtime avalaible checks.

Middleware (auth.go)
- Pre-Auth Check: Added DB health verification before JWT parsing
- Graceful Failure: Returns 503 "authentication service unavailable" when DB is down, blocking auth operations safely

Routes (route.go)
- Health endpoint: /health to return 
- 503 {"status":"degraded","db":"down"} when DB unavailable
- 200 {"status":"ok","db":"up"} when DB healthy


## Testing

1) Start the server when the DB is down:

<img width="1592" height="875" alt="image" src="https://github.com/user-attachments/assets/a83875b4-46c0-44f8-8666-c77020c4943f" />


2) Check health with db down


<img width="1635" height="253" alt="image" src="https://github.com/user-attachments/assets/69363c3d-8a97-49d8-a28b-e452176d6f5c" />



3) Start the DB while the server is running


<img width="1629" height="199" alt="image" src="https://github.com/user-attachments/assets/0abfa7d4-fad4-4fa4-82d4-4cfc72a69132" />


4) Stop DB while the server is running


<img width="1627" height="113" alt="image" src="https://github.com/user-attachments/assets/8346442f-c111-49f5-ab1d-ee06fc0b1f19" />


5) Test Auth Request with DB Down


<img width="1895" height="108" alt="image" src="https://github.com/user-attachments/assets/f99efab7-d274-4072-b5e9-f09cc0711f27" />


6) Restart server with db up


<img width="1903" height="418" alt="image" src="https://github.com/user-attachments/assets/77d86a8a-19bc-43b7-b2df-91894e97060e" />
